### PR TITLE
change github.com/gin-gonic/gin/examples/grpc/pb to github.com/gin-go…

### DIFF
--- a/grpc/gin/main.go
+++ b/grpc/gin/main.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	pb "github.com/gin-gonic/gin/examples/grpc/pb"
+	pb "github.com/gin-gonic/examples/grpc/pb"
 	"google.golang.org/grpc"
 )
 

--- a/grpc/grpc/server.go
+++ b/grpc/grpc/server.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net"
 
-	pb "github.com/gin-gonic/gin/examples/grpc/pb"
+	pb "github.com/gin-gonic/examples/grpc/pb"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"


### PR DESCRIPTION
Because  All gin examples has moved as alone repository to github.com/gin-gonic/examples,so we need change  github.com/gin-gonic/gin/examples/grpc/pb to github.com/gin-gonic/examples/grpc/pb