### PR TITLE
Update: examples/graceful-shutdown/graceful-shutdown/server.go

### DIFF
--- a/graceful-shutdown/graceful-shutdown/server.go
+++ b/graceful-shutdown/graceful-shutdown/server.go
@@ -35,7 +35,7 @@ func main() {
 
 	// Wait for interrupt signal to gracefully shutdown the server with
 	// a timeout of 5 seconds.
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 1)
 	// kill (no param) default send syscanll.SIGTERM
 	// kill -2 is syscall.SIGINT
 	// kill -9 is syscall. SIGKILL but can"t be catch, so don't need add it
@@ -49,9 +49,8 @@ func main() {
 		log.Fatal("Server Shutdown:", err)
 	}
 	// catching ctx.Done(). timeout of 5 seconds.
-	select {
-	case <-ctx.Done():
-		log.Println("timeout of 5 seconds.")
-	}
+	<-ctx.Done()
+	log.Println("timeout of 5 seconds.")
+
 	log.Println("Server exiting")
 }


### PR DESCRIPTION
Because staticcheck pointed out the following:
- SA1017 https://staticcheck.io/docs/checks#SA1017
- S1000 https://staticcheck.io/docs/checks#S1000

```sh
➜ staticcheck ./...                                                     
graceful-shutdown/graceful-shutdown/server.go:42:15: the channel used with signal.Notify should be buffered (SA1017)
graceful-shutdown/graceful-shutdown/server.go:52:2: should use a simple channel send/receive instead of select with a single case (S1000)

```