### PR TITLE
bookableDate fix

### DIFF
--- a/custom-validation/server.go
+++ b/custom-validation/server.go
@@ -22,7 +22,7 @@ func bookableDate(
 ) bool {
 	if date, ok := field.Interface().(time.Time); ok {
 		today := time.Now()
-		if today.Year() > date.Year() || today.YearDay() > date.YearDay() {
+		if today.Year() > date.Year() || (today.Year() == date.Year() && today.YearDay() > date.YearDay()) {
 			return false
 		}
 	}


### PR DESCRIPTION
Only `today.Year() == date.Year()`  we need compare YearDay.
Otherwise(`today.Year() < date.Year()`), We can return true directly.

for example:
today's YearDay is 251, 
Input `check_int=2020-01-01`, YearDay is 1,
because `today.YearDay() > date.YearDay() is true`
bookableDate function will return false (We expect to return true)