### PR TITLE
fix issus#29

### DIFF
--- a/custom-validation/server.go
+++ b/custom-validation/server.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
-	"github.com/go-playground/validator/v10"
+	"gopkg.in/go-playground/validator.v9"
+	//"github.com/go-playground/validator/v10"
 )
 
 // Booking contains binded and validated data.
 type Booking struct {
-	CheckIn  time.Time `form:"check_in" binding:"required" time_format:"2006-01-02"`
+	CheckIn  time.Time `form:"check_in" binding:"required,bookabledate" time_format:"2006-01-02"`
 	CheckOut time.Time `form:"check_out" binding:"required,gtfield=CheckIn" time_format:"2006-01-02"`
 }
 


### PR DESCRIPTION
1. CheckIn not add custom validator: bookabledate
2.using "github.com/go-playground/validator/v10" ,  v=nil and ok=false, so to change it to gopkg.in/go-playground/validator.v9.
3.Test 
$ curl -X GET "localhost:8085/bookable?check_in=2020-03-13&check_out=2020-03-16"
{"error":"Key: 'Booking.CheckIn' Error:Field validation for 'CheckIn' failed on the 'bookabledate' tag"}

$ curl -X GET "localhost:8085/bookable?check_in=2020-03-15&check_out=2020-03-16"
{"message":"Booking dates are valid!"}