### PR TITLE
Add bookabledate back into binding tag

### DIFF
--- a/custom-validation/server.go
+++ b/custom-validation/server.go
@@ -11,7 +11,7 @@ import (
 
 // Booking contains binded and validated data.
 type Booking struct {
-	CheckIn  time.Time `form:"check_in" binding:"required" time_format:"2006-01-02"`
+	CheckIn  time.Time `form:"check_in" binding:"required,bookabledate" time_format:"2006-01-02"`
 	CheckOut time.Time `form:"check_out" binding:"required,gtfield=CheckIn" time_format:"2006-01-02"`
 }
 


### PR DESCRIPTION
I believe it was taken out by mistake whilst @mosdeo was making a fix in 874dcfa6c457aa23996d67fa595a2acb8ea1f44b