### PR TITLE
Fix the log does not print err in reverse-proxy example

### DIFF
--- a/reverse-proxy/reverseServer/main.go
+++ b/reverse-proxy/reverseServer/main.go
@@ -44,7 +44,7 @@ func main() {
 		transport := http.DefaultTransport
 		resp, err := transport.RoundTrip(req)
 		if err != nil {
-			log.Printf("error in roundtrip: %v", resp)
+			log.Printf("error in roundtrip: %v", err)
 			c.String(500, "error")
 			return
 		}


### PR DESCRIPTION
Wrong variable is printed in the example
## before
```
2021/04/21 18:53:33 error in roundtrip: <nil>
```
## Now
```
2021/04/21 19:02:14 error in roundtrip: dial tcp 127.0.0.1:2003: connect: connection refused
```