### PR TITLE
template: use a shortcut for map[string]interface{}

### DIFF
--- a/template/main.go
+++ b/template/main.go
@@ -23,7 +23,7 @@ func main() {
 	router.LoadHTMLFiles("./testdata/raw.tmpl")
 
 	router.GET("/raw", func(c *gin.Context) {
-		c.HTML(http.StatusOK, "raw.tmpl", map[string]interface{}{
+		c.HTML(http.StatusOK, "raw.tmpl", gin.H{
 			"now": time.Date(2017, 07, 01, 0, 0, 0, 0, time.UTC),
 		})
 	})


### PR DESCRIPTION
Follow the guide [custom-template-funcs](https://pkg.go.dev/github.com/gin-gonic/gin#readme-custom-template-funcs), use a shortcut for map[string]interface{}. It's elegant.