### PR TITLE
use Request.Context().Done() instead

### DIFF
--- a/realtime-chat/main.go
+++ b/realtime-chat/main.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -28,7 +29,7 @@ func stream(c *gin.Context) {
 	listener := roomManager.OpenListener(roomid)
 	defer roomManager.CloseListener(roomid, listener)
 
-	clientGone := c.Writer.CloseNotify()
+	clientGone := c.Request.Context().Done()
 	c.Stream(func(w io.Writer) bool {
 		select {
 		case <-clientGone:


### PR DESCRIPTION
CloseNotifier has been deprecated(see https://pkg.go.dev/net/http#CloseNotifier), use Request.Context().Done() instead.