### PR TITLE
Fix deprecated go get command issue in assets-in-binary README.

### DIFF
--- a/assets-in-binary/example01/README.md
+++ b/assets-in-binary/example01/README.md
@@ -11,7 +11,7 @@ This is a complete example to create a single binary with the
 
 ```sh
 go get github.com/gin-gonic/gin
-go get github.com/jessevdk/go-assets-builder
+go install github.com/jessevdk/go-assets-builder@latest
 ```
 
 ### Generate assets.go


### PR DESCRIPTION
As the offical [go document](https://go.dev/doc/go-get-install-deprecation) describes:

> Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.

Therefore, `go-assets-builder` module executable should be installed by `go install` command instead of `go get` command.