### PR TITLE
fix: realtime-advanced examples

### DIFF
--- a/realtime-advanced/routes.go
+++ b/realtime-advanced/routes.go
@@ -21,8 +21,9 @@ func rateLimit(c *gin.Context) {
 		if value%200 == 0 {
 			fmt.Println("ip blocked")
 		}
-		c.Abort()
 		c.String(http.StatusServiceUnavailable, "you were automatically banned :)")
+		c.Abort()
+		return
 	}
 }
 


### PR DESCRIPTION
There seems to be a problem with the execution of custom middleware statements