### PR TITLE
SSE example: Fix server blocking on client channel

### DIFF
--- a/server-sent-event/main.go
+++ b/server-sent-event/main.go
@@ -126,6 +126,11 @@ func (stream *Event) serveHTTP() gin.HandlerFunc {
 		stream.NewClients <- clientChan
 
 		defer func() {
+			// Drain client channel so that it does not block. Server may keep sending messages to this channel
+			go func() {
+				for range clientChan {
+				}
+			}()
 			// Send closed connection to event server
 			stream.ClosedClients <- clientChan
 		}()


### PR DESCRIPTION
When SSE HTTP client disconnects handler function stops reading from `clientChan`, but server may block on this channel before it get notified by the means of `ClosedClients` channel.