### PR TITLE
Fix 404 error of jquery.form.js

### DIFF
--- a/realtime-chat/template.go
+++ b/realtime-chat/template.go
@@ -8,7 +8,7 @@ var html = template.Must(template.New("chat_room").Parse(`
     <title>{{.roomid}}</title>
     <link rel="stylesheet" type="text/css" href="http://meyerweb.com/eric/tools/css/reset/reset.css">
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.js"></script> 
-    <script src="http://malsup.github.com/jquery.form.js"></script> 
+    <script src="http://malsup.github.io/jquery.form.js"></script> 
     <script> 
         $('#message_form').focus();
         $(document).ready(function() { 


### PR DESCRIPTION
[http://malsup.github.com/jquery.form.js](http://malsup.github.com/jquery.form.js) returns 404. Use [http://malsup.github.io/jquery.form.js](http://malsup.github.io/jquery.form.js) instead.