### PR TITLE
allow messages to fail

### DIFF
--- a/server-sent-event/main.go
+++ b/server-sent-event/main.go
@@ -111,7 +111,11 @@ func (stream *Event) listen() {
 		// Broadcast message to client
 		case eventMsg := <-stream.Message:
 			for clientMessageChan := range stream.TotalClients {
-				clientMessageChan <- eventMsg
+				case clientMessageChan <- eventMsg:
+					// Message sent successfully
+				default:
+					// Client message channel full, dropping message
+				}
 			}
 		}
 	}

--- a/server-sent-event/main.go
+++ b/server-sent-event/main.go
@@ -114,7 +114,7 @@ func (stream *Event) listen() {
 				case clientMessageChan <- eventMsg:
 					// Message sent successfully
 				default:
-					// Client message channel full, dropping message
+					// Failed to send, dropping message
 				}
 			}
 		}


### PR DESCRIPTION
without the default statement busy servers can get stuck in this loop if the client disconnects while messages are being iterated over