### PR TITLE
fix: graceful-shutdown example

### DIFF
--- a/graceful-shutdown/close/server.go
+++ b/graceful-shutdown/close/server.go
@@ -25,7 +25,7 @@ func main() {
 		Handler: router,
 	}
 
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, os.Interrupt)
 
 	go func() {


### PR DESCRIPTION
Misuse of unbuffered os.Signal channel as argument to signal.Notify. From this [link](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/sigchanyzer)