### PR TITLE
fix(readme): update broken gin documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a number of ready-to-run examples demonstrating various use cases of [Gin](https://github.com/gin-gonic/gin).
 
-Refer to the [Gin documentation](https://gin-gonic.com/docs/) for how to execute the example tutorials.
+Refer to the [Gin documentation](https://gin-gonic.com/en/docs/) for how to execute the example tutorials.
 
 ## Contributing
 


### PR DESCRIPTION
Current link to documentation is broken (maybe moved idk).
This commit updates it to the correct URL (english docs).