### PR TITLE
feat(example): init ace-template example

### DIFF
--- a/ace-template/ace-example.ace
+++ b/ace-template/ace-example.ace
@@ -1,0 +1,4 @@
+= doctype html
+html
+  body
+    h1 Hello Ace & {{.Title}}

--- a/ace-template/main.go
+++ b/ace-template/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/yosssi/ace"
+)
+
+func setupRouter() *gin.Engine {
+	router := gin.Default()
+
+	router.GET("/ace-example", func(c *gin.Context) {
+		tpl, err := ace.Load("./ace-example", "", nil)
+		if err != nil {
+			panic(err)
+		}
+
+		err = tpl.Execute(c.Writer, gin.H{"Title": "Gin"})
+		if err != nil {
+			panic(err)
+		}
+	})
+
+	return router
+}
+
+func main() {
+	r := setupRouter()
+
+	r.Run(":3333")
+}

--- a/ace-template/main_test.go
+++ b/ace-template/main_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAceTemplate(t *testing.T) {
+	router := setupRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/ace-example", nil)
+	router.ServeHTTP(w, req)
+
+	expected := "<!DOCTYPE html><html><body><h1>Hello Ace & Gin</h1></body></html>"
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, expected, w.Body.String())
+}

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
+	github.com/yosssi/ace v0.0.5 // indirect
 	golang.org/x/arch v0.17.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+github.com/yosssi/ace v0.0.5 h1:tUkIP/BLdKqrlrPwcmH0shwEEhTRHoGnc1wFIWmaBUA=
+github.com/yosssi/ace v0.0.5/go.mod h1:ALfIzm2vT7t5ZE7uoIZqF3TQ7SAOyupFZnkrF5id+K0=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/ratelimit v0.3.1 h1:K4qVE+byfv/B3tC+4nYWP7v/6SimcO7HzHekoMNBma0=


### PR DESCRIPTION
Shows super minimalist example of how to render and serve *.ace template files.