### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/realtime-advanced/resources/room_login.templ.html
+++ b/realtime-advanced/resources/room_login.templ.html
@@ -184,7 +184,7 @@ func httpHandler(w http.ResponseWriter, req *http.Request) {
     sse.Encode(w, sse.Event{
         Id:    &quot;124&quot;,
         Event: &quot;message&quot;,
-        Data: map[string]interface{}{
+        Data: map[string]any{
             &quot;user&quot;:    &quot;manu&quot;,
             &quot;date&quot;:    time.Now().Unix(),
             &quot;content&quot;: &quot;hi!&quot;,

--- a/realtime-advanced/rooms.go
+++ b/realtime-advanced/rooms.go
@@ -4,13 +4,13 @@ import "github.com/dustin/go-broadcast"
 
 var roomChannels = make(map[string]broadcast.Broadcaster)
 
-func openListener(roomid string) chan interface{} {
-	listener := make(chan interface{})
+func openListener(roomid string) chan any {
+	listener := make(chan any)
 	room(roomid).Register(listener)
 	return listener
 }
 
-func closeListener(roomid string, listener chan interface{}) {
+func closeListener(roomid string, listener chan any) {
 	room(roomid).Unregister(listener)
 	close(listener)
 }

--- a/realtime-chat/rooms.go
+++ b/realtime-chat/rooms.go
@@ -12,7 +12,7 @@ type Message struct {
 
 type Listener struct {
 	RoomId string
-	Chan   chan interface{}
+	Chan   chan any
 }
 
 type Manager struct {
@@ -77,8 +77,8 @@ func (m *Manager) room(roomid string) broadcast.Broadcaster {
 	return b
 }
 
-func (m *Manager) OpenListener(roomid string) chan interface{} {
-	listener := make(chan interface{})
+func (m *Manager) OpenListener(roomid string) chan any {
+	listener := make(chan any)
 	m.open <- &Listener{
 		RoomId: roomid,
 		Chan:   listener,
@@ -86,7 +86,7 @@ func (m *Manager) OpenListener(roomid string) chan interface{} {
 	return listener
 }
 
-func (m *Manager) CloseListener(roomid string, channel chan interface{}) {
+func (m *Manager) CloseListener(roomid string, channel chan any) {
 	m.close <- &Listener{
 		RoomId: roomid,
 		Chan:   channel,


### PR DESCRIPTION
Replace `interface{}` with `any` (available since Go 1.18) in:
- `realtime-chat/rooms.go`
- `realtime-advanced/rooms.go`
- `realtime-advanced/resources/room_login.templ.html`