### PR TITLE
Add conditional routes example

### DIFF
--- a/conditional-routes/README.md
+++ b/conditional-routes/README.md
@@ -1,0 +1,21 @@
+# Conditional Routes
+
+This example demonstrates how to enable or disable routes using command-line flags and environment variables.
+
+## Run
+
+```bash
+go run main.go
+```
+
+Enable admin routes:
+
+```bash
+go run main.go --admin
+```
+
+Enable metrics endpoint:
+
+```bash
+ENABLE_METRICS=true go run main.go
+```

--- a/conditional-routes/main.go
+++ b/conditional-routes/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"flag"
+	"net/http"
+	"os"
+
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	enableAdmin := flag.Bool("admin", false, "Enable admin routes")
+	flag.Parse()
+
+	enableMetrics := os.Getenv("ENABLE_METRICS") == "true"
+
+	r := gin.Default()
+
+	// Public routes
+	r.GET("/", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"message": "Welcome to Gin",
+		})
+	})
+
+	r.GET("/health", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"status": "UP",
+		})
+	})
+
+	// Conditional admin routes
+	if *enableAdmin {
+		admin := r.Group("/admin")
+		{
+			admin.GET("/users", func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{
+					"message": "Admin users endpoint",
+				})
+			})
+
+			admin.GET("/settings", func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{
+					"message": "Admin settings endpoint",
+				})
+			})
+		}
+	}
+
+	// Conditional metrics route
+	if enableMetrics {
+		r.GET("/metrics", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{
+				"requests_total": 1234,
+				"uptime":         "24h",
+			})
+		})
+	}
+
+	r.Run(":8080")
+}


### PR DESCRIPTION
### Description

This PR adds a new example demonstrating conditional route registration in Gin.

The example shows how routes can be enabled or disabled at application startup using command-line flags and environment variables.

### Motivation

In production applications, it is common to conditionally expose:

* Admin APIs
* Metrics endpoints
* Debug endpoints
* Experimental features

This example demonstrates a simple and maintainable approach for registering routes based on configuration.

### Example Usage

```bash
go run main.go --admin
```

or

```bash
ENABLE_METRICS=true go run main.go
```

### Changes

* Added `conditional-routes` example
* Added README with usage instructions
* Added comments explaining the pattern
